### PR TITLE
Change 'enterprise-client' to 'usage-client'

### DIFF
--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -49,7 +49,6 @@ type Config struct {
 
 	Hostname string `toml:"hostname"`
 	DataDir  string `toml:"data_dir"`
-	Token    string `toml:"token"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -147,7 +147,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 	// append StatsService and ReportingService last so all stats are ready
 	// to be reported
 	s.appendStatsService(c.Stats)
-	s.appendReportingService(c.Reporting, c.Token)
+	s.appendReportingService(c.Reporting)
 
 	return s, nil
 }
@@ -306,10 +306,10 @@ func (s *Server) appendStatsService(c stats.Config) {
 	}
 }
 
-func (s *Server) appendReportingService(c reporting.Config, token string) {
+func (s *Server) appendReportingService(c reporting.Config) {
 	if c.Enabled {
 		l := s.LogService.NewLogger("[reporting] ", log.LstdFlags)
-		srv := reporting.NewService(c, token, l)
+		srv := reporting.NewService(c, l)
 
 		s.Services = append(s.Services, srv)
 	}

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -3,11 +3,6 @@
 hostname = "localhost"
 # Directory for storing a small amount of metadata about the server.
 data_dir = "/var/lib/kapacitor"
-# Your Enterprise token. By using Enterprise you can
-# send all internal statistics to the Enterprise
-# endpoints which will store and report on the
-# activity of your instances.
-token = ""
 
 [http]
   # HTTP API Server for Kapacitor
@@ -140,12 +135,7 @@ token = ""
   # Send anonymous usage statistics
   # every 12 hours to Enterprise.
   enabled = true
-  enterprise-url = "https://enterprise.influxdata.com"
-  # The interval at which to send all
-  # internal statistics to Enterprise.
-  # If no token is specified this
-  # setting has no effect.
-  stats-interval = "1m0s"
+  url = "https://usage.influxdata.com"
 
 ##################################
 # Input Methods, same as InfluxDB

--- a/services/reporting/config.go
+++ b/services/reporting/config.go
@@ -1,22 +1,17 @@
 package reporting
 
 import (
-	"time"
-
-	"github.com/influxdb/enterprise-client/v1"
-	"github.com/influxdb/influxdb/toml"
+	"github.com/influxdb/usage-client/v1"
 )
 
 type Config struct {
-	Enabled       bool          `toml:"enabled"`
-	EnterpriseURL string        `toml:"enterprise-url"`
-	StatsInterval toml.Duration `toml:"stats-interval"`
+	Enabled bool   `toml:"enabled"`
+	URL     string `toml:"url"`
 }
 
 func NewConfig() Config {
 	return Config{
-		Enabled:       true,
-		EnterpriseURL: client.URL,
-		StatsInterval: toml.Duration(time.Minute),
+		Enabled: true,
+		URL:     client.URL,
 	}
 }


### PR DESCRIPTION
`enterprise-client` will soon be repurposed for the on-prem solution, so we have renamed the existing `enterprise-client` to `usage-client`. It provides the same interface, but the backend endpoints for everything except anonymous usage reporting have been no-oped. I attempted to remove stats reporting from Kapacitor, however it seems that `client.StatsData` is used internally to facilitate writing TICK scripts against Kapacitor's own stats. Since this will require a bit more care than originally thought, for the time being this patch only switches the repos so that everything is reported to `usage.influxdata.com` instead of `enterprise.influxdata.com` (since we are repurposing that subdomain as well).