### PR TITLE
Add tm.Drain to task complete in replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugfixes
 - [#102](https://github.com/influxdb/kapacitor/issues/102): Fix race when start/stoping timeTicker in batch.go
+- [#106](https://github.com/influxdb/kapacitor/pull/106): Fix hang when replaying stream recording.
+
 
 ## v0.2.2 [2015-12-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Release Notes
 
+Bugfix #106 made a breaking change to the internal HTTP API. This was to facilitate integration testing and overall better design.
+Now POSTing a recording request will start the recording and immediately return. If you want to wait till it is complete do
+a GET for the recording info and it will block until its complete. The kapacitor cli has been updated accordingly.
+
 ### Features
 - [#96](https://github.com/influxdb/kapacitor/issues/96): Use KAPACITOR_URL env var for setting the kapacitord url in the client.
 - [#109](https://github.com/influxdb/kapacitor/pull/109): Add throughput counts to DOT format in `kapacitor show` command, if task is executing.

--- a/cmd/kapacitor/main.go
+++ b/cmd/kapacitor/main.go
@@ -304,7 +304,23 @@ func doRecord(args []string) error {
 	if rp.Error != "" {
 		return errors.New(rp.Error)
 	}
-	fmt.Println(rp.RecordingID)
+
+	v = url.Values{}
+	v.Add("id", rp.RecordingID)
+	r, err = http.Get(kapacitorEndpoint + "/record?" + v.Encode())
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	d = json.NewDecoder(r.Body)
+	ri := replay.RecordingInfo{}
+	d.Decode(&ri)
+	if ri.Error != "" {
+		return errors.New(ri.Error)
+	}
+
+	fmt.Println(ri.ID)
 	return nil
 }
 

--- a/task_master.go
+++ b/task_master.go
@@ -274,8 +274,6 @@ func (tm *TaskMaster) forkPoint(p models.Point) {
 }
 
 func (tm *TaskMaster) WritePoints(pts *cluster.WritePointsRequest) error {
-	tm.mu.RLock()
-	defer tm.mu.RUnlock()
 	if tm.closed {
 		return ErrTaskMasterClosed
 	}


### PR DESCRIPTION
With the refactor in #86 the replay engine wasn't properly draining the TaskMaster to that the tasks could run to completion. 

