### PR TITLE
Add edot to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 - [#96](https://github.com/influxdb/kapacitor/issues/96): Use KAPACITOR_URL env var for setting the kapacitord url in the client.
+- [#109](https://github.com/influxdb/kapacitor/pull/109): Add throughput counts to DOT format in `kapacitor show` command, if task is executing.
 
 ### Bugfixes
 - [#102](https://github.com/influxdb/kapacitor/issues/102): Fix race when start/stoping timeTicker in batch.go

--- a/cmd/kapacitord/run/server_test.go
+++ b/cmd/kapacitord/run/server_test.go
@@ -149,7 +149,7 @@ func TestServer_EnableTask(t *testing.T) {
 	if ti.TICKscript != tick {
 		t.Fatalf("unexpected TICKscript got %s exp %s", ti.TICKscript, tick)
 	}
-	dot := "digraph testTaskName {\nstream0 -> stream1;\n}"
+	dot := "digraph testTaskName {\nstream0 -> stream1 [label=\"0\"];\n}"
 	if ti.Dot != dot {
 		t.Fatalf("unexpected dot got %s exp %s", ti.Dot, dot)
 	}

--- a/edge.go
+++ b/edge.go
@@ -62,6 +62,10 @@ func newEdge(taskName, parentName, childName string, t pipeline.EdgeType, logSer
 	return e
 }
 
+func (e *Edge) collectedCount() string {
+	return e.statMap.Get(statCollected).String()
+}
+
 // Close the edge, this can only be called after all
 // collect calls to the edge have finished.
 func (e *Edge) Close() {

--- a/node.go
+++ b/node.go
@@ -1,6 +1,7 @@
 package kapacitor
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"runtime"
@@ -33,6 +34,9 @@ type Node interface {
 	closeChildEdges()
 	// abort parent edges
 	abortParentEdges()
+
+	// executing dot
+	edot(buf *bytes.Buffer)
 }
 
 //implementation of Node
@@ -146,5 +150,17 @@ func (n *node) linkChild(c Node) error {
 func (n *node) closeChildEdges() {
 	for _, child := range n.outs {
 		child.Close()
+	}
+}
+
+func (n *node) edot(buf *bytes.Buffer) {
+	for i, c := range n.children {
+		buf.Write([]byte(
+			fmt.Sprintf("%s -> %s [label=\"%s\"];\n",
+				n.Name(),
+				c.Name(),
+				n.outs[i].collectedCount(),
+			),
+		))
 	}
 }

--- a/services/task_store/service.go
+++ b/services/task_store/service.go
@@ -37,6 +37,7 @@ type Service struct {
 		StartTask(t *kapacitor.Task) (*kapacitor.ExecutingTask, error)
 		StopTask(name string) error
 		IsExecuting(name string) bool
+		ExecutingDot(name string) string
 	}
 	logger *log.Logger
 }
@@ -214,11 +215,16 @@ func (ts *Service) handleTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	executing := ts.TaskMaster.IsExecuting(name)
 	errMsg := raw.Error
 	dot := ""
 	task, err := ts.Load(name)
 	if err == nil {
-		dot = string(task.Dot())
+		if executing {
+			dot = ts.TaskMaster.ExecutingDot(name)
+		} else {
+			dot = string(task.Dot())
+		}
 	} else {
 		errMsg = err.Error()
 	}
@@ -230,7 +236,7 @@ func (ts *Service) handleTask(w http.ResponseWriter, r *http.Request) {
 		TICKscript: raw.TICKscript,
 		Dot:        dot,
 		Enabled:    ts.IsEnabled(name),
-		Executing:  ts.TaskMaster.IsExecuting(name),
+		Executing:  executing,
 		Error:      errMsg,
 	}
 

--- a/task.go
+++ b/task.go
@@ -1,6 +1,7 @@
 package kapacitor
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"log"
@@ -281,6 +282,24 @@ func (et *ExecutingTask) GetOutput(name string) (Output, error) {
 // Register a named output.
 func (et *ExecutingTask) registerOutput(name string, o Output) {
 	et.outputs[name] = o
+}
+
+// Return a graphviz .dot formatted byte array.
+// Label edges with relavant execution information.
+func (et *ExecutingTask) EDot() []byte {
+
+	var buf bytes.Buffer
+
+	buf.Write([]byte("digraph "))
+	buf.Write([]byte(et.Task.Name))
+	buf.Write([]byte(" {\n"))
+	et.walk(func(n Node) error {
+		n.edot(&buf)
+		return nil
+	})
+	buf.Write([]byte("}"))
+
+	return buf.Bytes()
 }
 
 // Create a  node from a given pipeline node.

--- a/task_master.go
+++ b/task_master.go
@@ -225,6 +225,16 @@ func (tm *TaskMaster) IsExecuting(name string) bool {
 	return executing
 }
 
+func (tm *TaskMaster) ExecutingDot(name string) string {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	et, executing := tm.tasks[name]
+	if executing {
+		return string(et.EDot())
+	}
+	return ""
+}
+
 func (tm *TaskMaster) Stream(name string) (StreamCollector, error) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()


### PR DESCRIPTION
Adds the throughput number to the DOT ouput of the `kapacitor` show command. This way you can get a quick glance without having to store and then query the internal stats.

Example DOT output:

```
digraph udp_drop {
stream0 -> stream1 [label="63921"];
stream1 -> groupby2 [label="143"];
groupby2 -> derivative3 [label="143"];
derivative3 -> window4 [label="142"];
window4 -> map5 [label="2"];
map5 -> reduce6 [label="2"];
reduce6 -> alert7 [label="2"];
}
```
 Read as 63921 points have been sent from stream0 to stream1. In this case meaning that the dbrp of the task has received 63921 points. Only 143 points where passed from stream1 to groupby2 meaning that only 143 points matched the from and where conditions of the task.

These throughput numbers are only displayed if the task is executing. 