### PR TITLE
Enable using TICKscript vars inside of lambda expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.2.4 [unreleased]
+
+### Release Notes
+
+### Features
+- [#107](https://github.com/influxdb/kapacitor/issues/107): Enable TICKscript variables to be defined and then referenced from lambda expressions.
+        Also fixes various bugs around using regexes.
+
+### Bugfixes
+
 ## v0.2.3 [2015-12-22]
 
 ### Release Notes

--- a/tick/TICKscript.md
+++ b/tick/TICKscript.md
@@ -52,6 +52,7 @@ duration_lit        = int_lit duration_unit .
 duration_unit       = "u" | "µ" | "ms" | "s" | "m" | "h" | "d" | "w" .
 string_lit          = `'` { unicode_char } `'` .
 star_lit            = "*"
+regex_lit           = `/` { unicode_char } `/` .
 
 operator_lit       = "+" | "-" | "*" | "/" | "==" | "!=" |
                      "<" | "<=" | ">" | ">=" | "=~" | "!~" |
@@ -60,14 +61,14 @@ operator_lit       = "+" | "-" | "*" | "/" | "==" | "!=" |
 Program      = Statement { Statement } .
 Statement    = Declaration | Expression .
 Declaration  = "var" identifier  "=" Expression .
-Expression   = identifier { Chain } | Function { Chain } .
+Expression   = identifier { Chain } | Function { Chain } | Primary .
 Chain        = "." Function { Chain} | "." identifier { Chain } .
 Function     = identifier "(" Parameters ")" .
 Parameters   = { Parameter "," } [ Parameter ] .
 Parameter    = Expression | "lambda:" LambdaExpr | Primary .
 Primary      = "(" LambdaExpr ")" | number_lit | string_lit |
                 boolean_lit | duration_lit | regex_lit | star_lit |
-                LFunc | Reference | "-" Primary | "!" Primary .
+                LFunc | identifier | Reference | "-" Primary | "!" Primary .
 Reference    = `"` { unicode_char } `"` .
 LambdaExpr   = Primary operator_lit Primary .
 LFunc        = identifier "(" LParameters ")"

--- a/tick/lex_test.go
+++ b/tick/lex_test.go
@@ -34,6 +34,13 @@ func TestLexer(t *testing.T) {
 	cases := []testCase{
 		//Symbols + Operators
 		{
+			in: "!",
+			tokens: []token{
+				token{tokenNot, 0, "!"},
+				token{tokenEOF, 1, ""},
+			},
+		},
+		{
 			in: "+",
 			tokens: []token{
 				token{tokenPlus, 0, "+"},
@@ -370,6 +377,40 @@ func TestLexer(t *testing.T) {
 				token{tokenEOF, 9, ""},
 			},
 		},
+		// Regex -- can only be lexed within context
+		{
+			in: `=~ //`,
+			tokens: []token{
+				token{tokenRegexEqual, 0, "=~"},
+				token{tokenRegex, 3, "//"},
+				token{tokenEOF, 5, ""},
+			},
+		},
+		{
+			in: `!~ //`,
+			tokens: []token{
+				token{tokenRegexNotEqual, 0, "!~"},
+				token{tokenRegex, 3, "//"},
+				token{tokenEOF, 5, ""},
+			},
+		},
+		{
+			in: `= //`,
+			tokens: []token{
+				token{tokenAsgn, 0, "="},
+				token{tokenRegex, 2, "//"},
+				token{tokenEOF, 4, ""},
+			},
+		},
+		{
+			in: `= /^((.*)[a-z]+\S{0,2})|cat\/\/$/`,
+			tokens: []token{
+				token{tokenAsgn, 0, "="},
+				token{tokenRegex, 2, `/^((.*)[a-z]+\S{0,2})|cat\/\/$/`},
+				token{tokenEOF, 33, ""},
+			},
+		},
+
 		//Space
 		{
 			in: " ",


### PR DESCRIPTION
Fixes #107 

You can now use vars in TICKscripts like this

```
var cpuThreshold = 10.0

stream.from()....
   .alert()
       .crit(lambda: "value" > cpuThreshold)
```

Vars can be any primitive type within TICKscript, namely: bools, numbers, string, durations, and regexp. 