### PR TITLE
added OpsGenie service for alerting

### DIFF
--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdb/kapacitor/services/httpd"
 	"github.com/influxdb/kapacitor/services/influxdb"
 	"github.com/influxdb/kapacitor/services/logging"
+	"github.com/influxdb/kapacitor/services/opsgenie"
 	"github.com/influxdb/kapacitor/services/pagerduty"
 	"github.com/influxdb/kapacitor/services/replay"
 	"github.com/influxdb/kapacitor/services/reporting"
@@ -41,6 +42,7 @@ type Config struct {
 	OpenTSDB  opentsdb.Config   `toml:"opentsdb"`
 	UDPs      []udp.Config      `toml:"udp"`
 	SMTP      smtp.Config       `toml:"smtp"`
+	OpsGenie  opsgenie.Config   `toml:"opsgenie"`
 	VictorOps victorops.Config  `toml:"victorops"`
 	PagerDuty pagerduty.Config  `toml:"pagerduty"`
 	Slack     slack.Config      `toml:"slack"`
@@ -65,6 +67,7 @@ func NewConfig() *Config {
 	c.Collectd = collectd.NewConfig()
 	c.OpenTSDB = opentsdb.NewConfig()
 	c.SMTP = smtp.NewConfig()
+	c.OpsGenie = opsgenie.NewConfig()
 	c.VictorOps = victorops.NewConfig()
 	c.PagerDuty = pagerduty.NewConfig()
 	c.Slack = slack.NewConfig()

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/influxdb/kapacitor/services/httpd"
 	"github.com/influxdb/kapacitor/services/influxdb"
 	"github.com/influxdb/kapacitor/services/logging"
+	"github.com/influxdb/kapacitor/services/opsgenie"
 	"github.com/influxdb/kapacitor/services/pagerduty"
 	"github.com/influxdb/kapacitor/services/replay"
 	"github.com/influxdb/kapacitor/services/reporting"
@@ -126,6 +127,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 	s.appendInfluxDBService(c.InfluxDB, c.Hostname)
 	s.appendTaskStoreService(c.Task)
 	s.appendReplayStoreService(c.Replay)
+	s.appendOpsGenieService(c.OpsGenie)
 	s.appendVictorOpsService(c.VictorOps)
 	s.appendPagerDutyService(c.PagerDuty)
 	s.appendSlackService(c.Slack)
@@ -208,6 +210,16 @@ func (s *Server) appendReplayStoreService(c replay.Config) {
 
 	s.ReplayService = srv
 	s.Services = append(s.Services, srv)
+}
+
+func (s *Server) appendOpsGenieService(c opsgenie.Config) {
+	if c.Enabled {
+		l := s.LogService.NewLogger("[opsgenie] ", log.LstdFlags)
+		srv := opsgenie.NewService(c, l)
+		s.TaskMaster.OpsGenieService = srv
+
+		s.Services = append(s.Services, srv)
+	}
 }
 
 func (s *Server) appendVictorOpsService(c victorops.Config) {

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -91,6 +91,26 @@ data_dir = "/var/lib/kapacitor"
   # Close idle connections after timeout
   idle-timeout = "30s"
 
+[opsgenie]
+    # Configure OpsGenie with your API key and default routing key.
+    enabled = false
+    # Your OpsGenie API Key.
+    api-key = ""
+    # Default OpsGenie teams, can be overridden per alert.
+    # teams = ["team1", "team2"]
+    # Default OpsGenie recipients, can be overridden per alert.
+    # recipients = ["recipient1", "recipient2"]
+    # The OpsGenie API URL should not need to be changed.
+    url = "https://api.opsgenie.com/v1/json/alert"
+    # The OpsGenie Recovery URL, you can change this
+    # based on which behavior you want a recovery to
+    # trigger (Add Notes, Close Alert, etc.)
+    recovery_url = "https://api.opsgenie.com/v1/json/alert/note"
+    # If true then all alerts will be sent to OpsGenie
+    # without explicity marking them in the TICKscript.
+    # The team and recipients can still be overridden.
+    global = false
+
 [victorops]
   # Configure VictorOps with your API key and default routing key.
   enabled = false

--- a/integrations/streamer_test.go
+++ b/integrations/streamer_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdb/kapacitor"
 	"github.com/influxdb/kapacitor/clock"
 	"github.com/influxdb/kapacitor/services/httpd"
+	"github.com/influxdb/kapacitor/services/opsgenie"
 	"github.com/influxdb/kapacitor/services/pagerduty"
 	"github.com/influxdb/kapacitor/services/slack"
 	"github.com/influxdb/kapacitor/services/victorops"
@@ -1164,6 +1165,97 @@ stream
 	c.Channel = "#channel"
 	sl := slack.NewService(c, logService.NewLogger("[test_slack] ", log.LstdFlags))
 	tm.SlackService = sl
+
+	err := fastForwardTask(clock, et, replayErr, tm, 13*time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if requestCount != 1 {
+		t.Errorf("unexpected requestCount got %d exp 1", requestCount)
+	}
+}
+
+func TestStream_AlertOpsGenie(t *testing.T) {
+	requestCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		type postData struct {
+			ApiKey      string                 `json:"apiKey"`
+			Message     string                 `json:"message"`
+			Entity      string                 `json:"entity"`
+			Alias       string                 `json:"alias"`
+			Note        int                    `json:"note"`
+			Details     map[string]interface{} `json:"details"`
+			Description interface{}            `json:"description"`
+			Teams       []string               `json:"teams"`
+			Recipients  []string               `json:"recipients"`
+		}
+
+		pd := postData{}
+		dec := json.NewDecoder(r.Body)
+		dec.Decode(&pd)
+
+		if exp := "CRITICAL"; pd.Details["Level"] != exp {
+			t.Errorf("unexpected level got %s exp %s", pd.Details["level"], exp)
+		}
+		if exp := "kapacitor/cpu/serverA"; pd.Entity != exp {
+			t.Errorf("unexpected entity got %s exp %s", pd.Entity, exp)
+		}
+		if exp := "kapacitor/cpu/serverA"; pd.Alias != exp {
+			t.Errorf("unexpected alias got %s exp %s", pd.Alias, exp)
+		}
+		if exp := "kapacitor/cpu/serverA is CRITICAL"; pd.Message != exp {
+			t.Errorf("unexpected entity id got %s exp %s", pd.Message, exp)
+		}
+		if exp := "Kapacitor"; pd.Details["Monitoring Tool"] != exp {
+			t.Errorf("unexpected monitoring tool got %s exp %s", pd.Details["Monitoring Tool"], exp)
+		}
+		if pd.Description == nil {
+			t.Error("unexpected description got nil")
+		}
+		if exp := "test_team"; pd.Teams[0] != exp {
+			t.Errorf("unexpected teams[0] got %s exp %s", pd.Teams[0], exp)
+		}
+		if exp := "another_team"; pd.Teams[1] != exp {
+			t.Errorf("unexpected teams[1] got %s exp %s", pd.Teams[1], exp)
+		}
+		if exp := "test_recipient"; pd.Recipients[0] != exp {
+			t.Errorf("unexpected recipients[0] got %s exp %s", pd.Recipients[0], exp)
+		}
+		if exp := "another_recipient"; pd.Recipients[1] != exp {
+			t.Errorf("unexpected recipients[1] got %s exp %s", pd.Recipients[1], exp)
+		}
+	}))
+	defer ts.Close()
+
+	var script = `
+stream
+	.from().measurement('cpu')
+	.where(lambda: "host" == 'serverA')
+	.groupBy('host')
+	.window()
+		.period(10s)
+		.every(10s)
+	.mapReduce(influxql.count('idle'))
+	.alert()
+		.id('kapacitor/{{ .Name }}/{{ index .Tags "host" }}')
+		.info(lambda: "count" > 6.0)
+		.warn(lambda: "count" > 7.0)
+		.crit(lambda: "count" > 8.0)
+		.opsGenie()
+		.teams('test_team', 'another_team')
+		.recipients('test_recipient', 'another_recipient')
+`
+
+	clock, et, replayErr, tm := testStreamer(t, "TestStream_Alert", script)
+	defer tm.Close()
+	c := opsgenie.NewConfig()
+	c.URL = ts.URL
+	c.APIKey = "api_key"
+	og := opsgenie.NewService(c, logService.NewLogger("[test_og] ", log.LstdFlags))
+	tm.OpsGenieService = og
 
 	err := fastForwardTask(clock, et, replayErr, tm, 13*time.Second)
 	if err != nil {

--- a/services/opsgenie/config.go
+++ b/services/opsgenie/config.go
@@ -1,0 +1,28 @@
+package opsgenie
+
+const DefaultOpsGenieAPIURL = "https://api.opsgenie.com/v1/json/alert"
+const DefaultOpsGenieRecoveryURL = "https://api.opsgenie.com/v1/json/alert/note"
+
+type Config struct {
+	// Whether to enable OpsGenie integration.
+	Enabled bool
+	// The OpsGenie API key.
+	APIKey string `toml:"api-key"`
+	// The default Teams, can be overriden per alert.
+	Teams []string `toml:"teams"`
+	// The default Teams, can be overriden per alert.
+	Recipients []string `toml:"recipients"`
+	// The OpsGenie API URL, should not need to be changed.
+	URL string `toml:"url"`
+	// The OpsGenie Recovery URL, you can change this based on which behavior you want a recovery to trigger (Add Notes, Close Alert, etc.)
+	RecoveryURL string `toml:"recovery_url"`
+	// Whether every alert should automatically go to OpsGenie.
+	Global bool `toml:"global"`
+}
+
+func NewConfig() Config {
+	return Config{
+		URL:         DefaultOpsGenieAPIURL,
+		RecoveryURL: DefaultOpsGenieRecoveryURL,
+	}
+}

--- a/services/opsgenie/service.go
+++ b/services/opsgenie/service.go
@@ -1,0 +1,119 @@
+package opsgenie
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/influxdb/kapacitor"
+)
+
+type Service struct {
+	apikey       string
+	teams        []string
+	recipients   []string
+	url          string
+	recovery_url string
+	global       bool
+	logger       *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	return &Service{
+		teams:        c.Teams,
+		recipients:   c.Recipients,
+		apikey:       c.APIKey,
+		url:          c.URL + "/",
+		recovery_url: c.RecoveryURL + "/",
+		global:       c.Global,
+		logger:       l,
+	}
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) Global() bool {
+	return s.global
+}
+
+func (s *Service) Alert(teams []string, recipients []string, messageType, message, entityID string, t time.Time, details interface{}) error {
+	ogData := make(map[string]interface{})
+	url := s.url
+
+	ogData["apiKey"] = s.apikey
+	ogData["entity"] = entityID
+	ogData["alias"] = entityID
+	ogData["message"] = message
+	ogData["note"] = ""
+	ogData["monitoring_tool"] = kapacitor.Product
+
+	//Extra Fields (can be used for filtering)
+	ogDetails := make(map[string]interface{})
+	ogDetails["Level"] = messageType
+	ogDetails["Monitoring Tool"] = "Kapacitor"
+
+	ogData["details"] = ogDetails
+
+	switch messageType {
+	case "RECOVERY":
+		url = s.recovery_url
+		ogData["note"] = message
+	}
+
+	if details != nil {
+		b, err := json.Marshal(details)
+		if err != nil {
+			return err
+		}
+		ogData["description"] = string(b)
+	}
+
+	if len(teams) == 0 {
+		teams = s.teams
+	}
+
+	if len(teams) > 0 {
+		ogData["teams"] = teams
+	}
+
+	if len(recipients) == 0 {
+		recipients = s.recipients
+	}
+
+	if len(recipients) > 0 {
+		ogData["recipients"] = recipients
+	}
+
+	// Post data to VO
+	var post bytes.Buffer
+	enc := json.NewEncoder(&post)
+	err := enc.Encode(ogData)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(url, "application/json", &post)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		type response struct {
+			Message string `json:"message"`
+		}
+		r := &response{Message: "failed to understand OpsGenie response"}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(r)
+		return errors.New(r.Message)
+	}
+	return nil
+}

--- a/task_master.go
+++ b/task_master.go
@@ -35,6 +35,10 @@ type TaskMaster struct {
 		Global() bool
 		SendMail(to []string, subject string, msg string)
 	}
+	OpsGenieService interface {
+		Global() bool
+		Alert(teams []string, recipients []string, messageType, message, entityID string, t time.Time, details interface{}) error
+	}
 	VictorOpsService interface {
 		Global() bool
 		Alert(routingKey, messageType, message, entityID string, t time.Time, extra interface{}) error


### PR DESCRIPTION
Implements #71 

I am running this code in our production environment, and have been getting OpsGenie alerts since 12/18/2015.

Usage:
```
stream
	.from().measurement('cpu')
	.where(lambda: "host" == 'serverA')
	.groupBy('host')
	.window()
		.period(10s)
		.every(10s)
	.mapReduce(influxql.count('idle'))
	.alert()
		.id('kapacitor/{{ .Name }}/{{ index .Tags "host" }}')
		.info(lambda: "count" > 6.0)
		.warn(lambda: "count" > 7.0)
		.crit(lambda: "count" > 8.0)
		.opsGenie()
		.ogTeams('test_team,another_team')
		.ogRecipients('test_recipient,another_recipient')
```

Configuration:
```
[opsgenie]
    # Configure OpsGenie with your API key and default routing key.
    enabled = false
    # Your OpsGenie API Key.
    api-key = ""
    # Default OpsGenie teams, can be overridden per alert.
    teams = ""
    # Default OpsGenie recipients, can be overridden per alert.
    recipients = ""
    # The OpsGenie API URL should not need to be changed.
    url = "https://api.opsgenie.com/v1/json/alert"
    # The OpsGenie Recovery URL, you can change this
    # based on which behavior you want a recovery to
    # trigger (Add Notes, Close Alert, etc.)
    recovery_url = "https://api.opsgenie.com/v1/json/alert/note"
    # If true the all alerts will be sent to OpsGenie
    # without explicity marking them in the TICKscript.
    # The routing key can still be overridden.
    global = false
```

This is my first run at working with Go, so some changes may be necessary. This is mainly a copy of the VictorOps service, modified to work properly with OpsGenie.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [X] Tests pass
- [X] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)