### PR TITLE
Allow for multiple alert handlers of the same type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Release Notes
 
 ### Features
+- [#118](https://github.com/influxdb/kapacitor/issues/118): Can now define multiple handlers of the same type on an AlertNode.
+- [#113](https://github.com/influxdb/kapacitor/issues/113): OpsGenie support thanks! @ericiles
 - [#107](https://github.com/influxdb/kapacitor/issues/107): Enable TICKscript variables to be defined and then referenced from lambda expressions.
         Also fixes various bugs around using regexes.
 

--- a/pipeline/influxdb_out.go
+++ b/pipeline/influxdb_out.go
@@ -12,7 +12,7 @@ package pipeline
 //            .retentionPolicy('myrp')
 //            .measurement('errors')
 //            .tag('kapacitor', 'true')
-//            .tag('version', '0.1')
+//            .tag('version', '0.2')
 //
 type InfluxDBOutNode struct {
 	node

--- a/update_tick_docs.sh
+++ b/update_tick_docs.sh
@@ -5,7 +5,7 @@
 # of structs into property methods and chaining methods.
 
 dest=$1 # output path for the .md files
-docspath=${2-/docs/kapacitor/v0.1/tick}
+docspath=${2-/kapacitor/v0.2/tick}
 
 if [ -z "$dest" ]
 then


### PR DESCRIPTION
Fixes #118 

With this change each alert handler is appropriately scoped so you do not have to worry about name conflicts. You can now add multiple handlers of the same type. 

For example:

```
stream
	.from().measurement('cpu')
	.where(lambda: "host" == 'serverA')
	.groupBy('host')
	.window()
		.period(10s)
		.every(10s)
	.mapReduce(influxql.count('idle'))
	.alert()
		.id('kapacitor/{{ .Name }}/{{ index .Tags "host" }}')
		.info(lambda: "count" > 6.0)
		.warn(lambda: "count" > 7.0)
		.crit(lambda: "count" > 8.0)
		.slack()
			.channel('#alerts')
		.slack()
			.channel('@jim')
```