### PR TITLE
Added HipChat service for alerting.

### DIFF
--- a/cmd/kapacitord/run/config.go
+++ b/cmd/kapacitord/run/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/influxdb/kapacitor/services/hipchat"
 	"github.com/influxdb/kapacitor/services/httpd"
 	"github.com/influxdb/kapacitor/services/influxdb"
 	"github.com/influxdb/kapacitor/services/logging"
@@ -46,6 +47,7 @@ type Config struct {
 	VictorOps victorops.Config  `toml:"victorops"`
 	PagerDuty pagerduty.Config  `toml:"pagerduty"`
 	Slack     slack.Config      `toml:"slack"`
+	HipChat   hipchat.Config    `toml:"hipchat"`
 	Reporting reporting.Config  `toml:"reporting"`
 	Stats     stats.Config      `toml:"stats"`
 
@@ -71,6 +73,7 @@ func NewConfig() *Config {
 	c.VictorOps = victorops.NewConfig()
 	c.PagerDuty = pagerduty.NewConfig()
 	c.Slack = slack.NewConfig()
+	c.HipChat = hipchat.NewConfig()
 	c.Reporting = reporting.NewConfig()
 	c.Stats = stats.NewConfig()
 

--- a/cmd/kapacitord/run/server.go
+++ b/cmd/kapacitord/run/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/influxdb/influxdb/services/graphite"
 	"github.com/influxdb/influxdb/services/opentsdb"
 	"github.com/influxdb/kapacitor"
+	"github.com/influxdb/kapacitor/services/hipchat"
 	"github.com/influxdb/kapacitor/services/httpd"
 	"github.com/influxdb/kapacitor/services/influxdb"
 	"github.com/influxdb/kapacitor/services/logging"
@@ -130,6 +131,7 @@ func NewServer(c *Config, buildInfo *BuildInfo, logService logging.Interface) (*
 	s.appendOpsGenieService(c.OpsGenie)
 	s.appendVictorOpsService(c.VictorOps)
 	s.appendPagerDutyService(c.PagerDuty)
+	s.appendHipChatService(c.HipChat)
 	s.appendSlackService(c.Slack)
 
 	// Append InfluxDB services
@@ -248,6 +250,16 @@ func (s *Server) appendSlackService(c slack.Config) {
 		l := s.LogService.NewLogger("[slack] ", log.LstdFlags)
 		srv := slack.NewService(c, l)
 		s.TaskMaster.SlackService = srv
+
+		s.Services = append(s.Services, srv)
+	}
+}
+
+func (s *Server) appendHipChatService(c hipchat.Config) {
+	if c.Enabled {
+		l := s.LogService.NewLogger("[hipchat] ", log.LstdFlags)
+		srv := hipchat.NewService(c, l)
+		s.TaskMaster.HipChatService = srv
 
 		s.Services = append(s.Services, srv)
 	}

--- a/etc/kapacitor/kapacitor.conf
+++ b/etc/kapacitor/kapacitor.conf
@@ -150,6 +150,22 @@ data_dir = "/var/lib/kapacitor"
   # without explicity marking them in the TICKscript.
   global = false
 
+[hipchat]
+  # Configure HipChat.
+  enabled = false
+  # The HipChat API URL. Replace subdomain with your
+  # HipChat subdomain.
+  url = "https://subdomain.hipchat.com/v2/room"
+  # Visit https://www.hipchat.com/docs/apiv2
+  # for information on obtaining your room id and
+  # authentication token.
+  # Default room for messages
+  room = ""
+  # Default authentication token
+  token = ""
+  # If true then all alerts will be sent to HipChat
+  # without explicitly marking them in the TICKscript.
+  global = false
 
 [reporting]
   # Send anonymous usage statistics

--- a/services/hipchat/config.go
+++ b/services/hipchat/config.go
@@ -1,0 +1,19 @@
+package hipchat
+
+type Config struct {
+	// Whether HipChat integration is enabled.
+	Enabled bool `toml:"enabled"`
+	// The HipChat API URL.
+	URL string `toml:"url"`
+	// The authentication token for this notification, can be overridden per alert.
+	// https://www.hipchat.com/docs/apiv2/auth for info on obtaining a token.
+	Token string `toml:"token"`
+	// The default room, can be overridden per alert.
+	Room string `toml:"room"`
+	// Whether all alerts should automatically post to HipChat
+	Global bool `toml:"global"`
+}
+
+func NewConfig() Config {
+	return Config{}
+}

--- a/services/hipchat/service.go
+++ b/services/hipchat/service.go
@@ -1,0 +1,98 @@
+package hipchat
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/influxdb/kapacitor"
+)
+
+type Service struct {
+	room   string
+	token  string
+	url    string
+	global bool
+	logger *log.Logger
+}
+
+func NewService(c Config, l *log.Logger) *Service {
+	return &Service{
+		room:   c.Room,
+		token:  c.Token,
+		url:    c.URL,
+		global: c.Global,
+		logger: l,
+	}
+}
+
+func (s *Service) Open() error {
+	return nil
+}
+
+func (s *Service) Close() error {
+	return nil
+}
+
+func (s *Service) Global() bool {
+	return s.global
+}
+
+func (s *Service) Alert(room, token, message string, level kapacitor.AlertLevel) error {
+
+	//Generate HipChat API Url including room and authentication token
+	if room == "" {
+		room = s.room
+	}
+	if token == "" {
+		token = s.token
+	}
+
+	var Url *url.URL
+	Url, err := url.Parse(s.url + "/" + room + "/notification?auth_token=" + token)
+	if err != nil {
+		return err
+	}
+
+	var color string
+	switch level {
+	case kapacitor.WarnAlert:
+		color = "yellow"
+	case kapacitor.CritAlert:
+		color = "red"
+	default:
+		color = "green"
+	}
+
+	postData := make(map[string]interface{})
+	postData["from"] = kapacitor.Product
+	postData["color"] = color
+	postData["message"] = message
+	postData["notify"] = true
+
+	var post bytes.Buffer
+	enc := json.NewEncoder(&post)
+	err = enc.Encode(postData)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(Url.String(), "application/json", &post)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		type response struct {
+			Error string `json:"error"`
+		}
+		r := &response{Error: "failed to understand HipChat response"}
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(r)
+		return errors.New(r.Error)
+	}
+	return nil
+}

--- a/task_master.go
+++ b/task_master.go
@@ -51,6 +51,10 @@ type TaskMaster struct {
 		Global() bool
 		Alert(channel, message string, level AlertLevel) error
 	}
+	HipChatService interface {
+		Global() bool
+		Alert(room, token, message string, level AlertLevel) error
+	}
 	LogService LogService
 
 	// Incoming streams


### PR DESCRIPTION
Implements #119 

This code has been tested and has successfully sent alerts to HipChat as of 12/28/2015.

Usage:
```
stream
	.from().measurement('cpu')
	.where(lambda: "host" == 'serverA')
	.groupBy('host')
	.window()
		.period(10s)
		.every(10s)
	.mapReduce(influxql.count('idle'))
	.alert()
		.id('kapacitor/{{ .Name }}/{{ index .Tags "host" }}')
		.info(lambda: "count" > 6.0)
		.warn(lambda: "count" > 7.0)
		.crit(lambda: "count" > 8.0)
		.hipChat()
			.room('1234567')
			.token('testtoken1234567')
```

Configuration:
```
[hipchat]
  # Configure HipChat.
  enabled = false
  # The HipChat API URL. Replace subdomain with your
  # HipChat subdomain.
  url = "https://subdomain.hipchat.com/v2/room"
  # Visit https://www.hipchat.com/docs/apiv2
  # for information on obtaining your room id and
  # authentication token.
  # Default room for messages
  room = ""
  # Default authentication token
  token = ""
  # If true then all alerts will be sent to HipChat
  # without explicitly marking them in the TICKscript.
  global = false
```

- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [X] Tests pass
- [X] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)